### PR TITLE
Feature: add endpoint to get the general ranking

### DIFF
--- a/src/main/java/com/example/backend/controller/CatController.java
+++ b/src/main/java/com/example/backend/controller/CatController.java
@@ -31,6 +31,11 @@ public class CatController {
         return catService.getAll();
     }
 
+    @GetMapping("/ranked")
+    public List<Cat> getAllRanked() {
+        return catService.getAllRanked();
+    }
+
     @PatchMapping("/{id}/number-of-votes")
     public ResponseEntity<String> incrementNumberOfVotes(@PathVariable String id) {
         boolean updated = catService.incrementNumberOfVotes(id);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=backend
+cats.data.file=/cats.json

--- a/src/test/java/com/example/backend/controller/CatControllerTest.java
+++ b/src/test/java/com/example/backend/controller/CatControllerTest.java
@@ -50,6 +50,19 @@ class CatControllerTest {
                 .andExpect(jsonPath("$[0].id").value("46h"))
                 .andExpect(jsonPath("$[1].id").value("bd8"));
     }
+
+    @Test
+    void testGetAllRanked() throws Exception {
+        cat1.setNumberOfVotes(1);
+        cat2.setNumberOfVotes(4);
+        List<Cat> cats = Arrays.asList(cat2, cat1);
+        Mockito.when(catService.getAllRanked()).thenReturn(cats);
+
+        mockMvc.perform(get("/api/cats/ranked"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(cat2.getId()))
+                .andExpect(jsonPath("$[1].id").value(cat1.getId()));
+    }
     
     @Test
     void testGetByIdExists() throws Exception {

--- a/src/test/java/com/example/backend/service/CatServiceTest.java
+++ b/src/test/java/com/example/backend/service/CatServiceTest.java
@@ -13,12 +13,15 @@ import static org.junit.jupiter.api.Assertions.*;
 class CatServiceTest {
 
     private CatService catService;
-    private String existingId = "46h";
-    private String nonExistingId = "123abc";
+    private String existingId = "1";
+    private String nonExistingId = "4";
+    private String firstSpotId = "2";
+    private String secondSpotId = "3";
+    private String thridSpotId = "1";
 
     @BeforeEach
     void setUp() {
-        catService = new CatService();
+        catService = new CatService("/cats-test.json");
         catService.init();
     }
 
@@ -26,6 +29,14 @@ class CatServiceTest {
     void testGetAllNotEmpty() {
         List<Cat> cats = catService.getAll();
         assertFalse(cats.isEmpty(), "List should not be empty");
+    }
+
+    @Test
+    void testGetAllRanked() {
+        List<Cat> cats = catService.getAllRanked();
+        assertEquals(cats.get(0).getId(), firstSpotId, String.format("Cat with id %s should occupy the first spot", firstSpotId));
+        assertEquals(cats.get(1).getId(), secondSpotId, String.format("Cat with id %s should occupy the second spot", secondSpotId));
+        assertEquals(cats.get(2).getId(), thridSpotId, String.format("Cat with id %s should occupy the third spot", thridSpotId));
     }
 
     @Test
@@ -45,14 +56,11 @@ class CatServiceTest {
         Optional<Cat> cat = catService.getById(existingId);
         assertTrue(cat.isPresent());
 
-        int numberOfVotesBefore = cat.get().getNumberOfVotes();
-        assertEquals(numberOfVotesBefore, 0);
-
         boolean updated = catService.incrementNumberOfVotes(existingId);
         int numberOfVotesAfter = cat.get().getNumberOfVotes();
 
         assertTrue(updated, "The number of votes should have been updated.");
-        assertEquals(numberOfVotesAfter, 1, String.format("There should be one vote for cat with id %s", existingId));
+        assertEquals(numberOfVotesAfter, 2, String.format("There should be one vote for cat with id %s", existingId));
     }
 
     @Test

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,1 @@
+cats.data.file=/cats-test.json

--- a/src/test/resources/cats-test.json
+++ b/src/test/resources/cats-test.json
@@ -1,0 +1,17 @@
+[
+  {
+    "url": "http://24.media.tumblr.com/tumblr_m82woaL5AD1rro1o5o1_1280.jpg",
+    "id": "1",
+    "numberOfVotes": 1
+  },
+  {
+    "url": "http://24.media.tumblr.com/tumblr_m29a9d62C81r2rj8po1_500.jpg",
+    "id": "2",
+    "numberOfVotes": 5
+  },
+  {
+    "url": "http://25.media.tumblr.com/tumblr_m4bgd9OXmw1qioo2oo1_500.jpg",
+    "id": "3",
+    "numberOfVotes": 3
+  }
+]


### PR DESCRIPTION
Create an endpoint to provide the list of all cats sorted (according to the number of votes) to get the ranking directly.
A bit of refactoring has been made in `CatService` to be able to inject a custom JSON dataset during tests.